### PR TITLE
Replace existing site with Arkridge single-page canvas landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,38 +1,213 @@
-import React from 'react';
-import UnderConstruction from './components/UnderConstruction';
-import Navbar from './components/Navbar';
-import Hero from './sections/Hero';
-import About from './sections/About';
-import Industries from './sections/Industries';
-import Brands from './sections/Brands';
-import Capabilities from './sections/Capabilities';
-import Contact from './sections/Contact';
-import Footer from './components/Footer';
+import { useEffect, useRef } from 'react';
 
 function App() {
-  // Check if the site is in under construction mode
-  const isUnderConstruction = import.meta.env.VITE_UNDER_CONSTRUCTION === 'true';
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const cursorRef = useRef<HTMLDivElement>(null);
+  const cursorRingRef = useRef<HTMLDivElement>(null);
+  const contactRef = useRef<HTMLAnchorElement>(null);
 
-  // If under construction, show only the under construction page
-  if (isUnderConstruction) {
-    return <UnderConstruction />;
-  }
+  useEffect(() => {
+    const contactLink = contactRef.current;
+    const dot = cursorRef.current;
+    const ring = cursorRingRef.current;
+    const canvas = canvasRef.current;
 
-  // Otherwise, show the normal site
+    if (!contactLink || !dot || !ring || !canvas) {
+      return;
+    }
+
+    const parts = ['info', '@', 'arkridgeindustries', '.com'];
+    contactLink.href = `mailto:${parts.join('')}`;
+
+    let mx = window.innerWidth / 2;
+    let my = window.innerHeight / 2;
+    let rx = mx;
+    let ry = my;
+
+    const onMouseMove = (event: MouseEvent) => {
+      mx = event.clientX;
+      my = event.clientY;
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+
+    let cursorAnimationId = 0;
+    const tickCursor = () => {
+      dot.style.left = `${mx}px`;
+      dot.style.top = `${my}px`;
+      rx += (mx - rx) * 0.12;
+      ry += (my - ry) * 0.12;
+      ring.style.left = `${rx}px`;
+      ring.style.top = `${ry}px`;
+      cursorAnimationId = window.requestAnimationFrame(tickCursor);
+    };
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      return;
+    }
+
+    let width = 0;
+    let height = 0;
+    let centerX = 0;
+    let centerY = 0;
+
+    const colors = [
+      [255, 255, 255],
+      [210, 222, 230],
+      [165, 185, 200],
+      [110, 140, 160],
+      [70, 100, 120],
+    ];
+
+    const count = 160;
+    let points: Array<{
+      x: number;
+      y: number;
+      vx: number;
+      vy: number;
+      r: number;
+      op: number;
+      cr: number;
+      cg: number;
+      cb: number;
+    }> = [];
+
+    const resize = () => {
+      width = canvas.width = window.innerWidth;
+      height = canvas.height = window.innerHeight;
+      centerX = width / 2;
+      centerY = height / 2;
+    };
+
+    const init = () => {
+      points = [];
+      for (let i = 0; i < count; i += 1) {
+        const color = colors[Math.floor(Math.random() * colors.length)];
+        points.push({
+          x: Math.random() * width,
+          y: Math.random() * height,
+          vx: (Math.random() - 0.5) * 0.3,
+          vy: (Math.random() - 0.5) * 0.3,
+          r: Math.random() * 1.2 + 0.2,
+          op: Math.random() * 0.45 + 0.08,
+          cr: color[0],
+          cg: color[1],
+          cb: color[2],
+        });
+      }
+    };
+
+    const onResize = () => {
+      resize();
+      init();
+    };
+
+    resize();
+    init();
+    window.addEventListener('resize', onResize);
+
+    ctx.fillStyle = '#2A3138';
+    ctx.fillRect(0, 0, width, height);
+
+    let canvasAnimationId = 0;
+    const draw = () => {
+      ctx.fillStyle = 'rgba(42,49,56,0.2)';
+      ctx.fillRect(0, 0, width, height);
+
+      const vignette = ctx.createRadialGradient(centerX, centerY, height * 0.1, centerX, centerY, height * 0.85);
+      vignette.addColorStop(0, 'transparent');
+      vignette.addColorStop(1, 'rgba(10,14,18,0.75)');
+      ctx.fillStyle = vignette;
+      ctx.fillRect(0, 0, width, height);
+
+      const glow = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, Math.min(width, height) * 0.38);
+      glow.addColorStop(0, 'rgba(255,255,255,0.018)');
+      glow.addColorStop(1, 'transparent');
+      ctx.fillStyle = glow;
+      ctx.fillRect(0, 0, width, height);
+
+      for (let i = 0; i < count; i += 1) {
+        const point = points[i];
+        point.x += point.vx;
+        point.y += point.vy;
+        if (point.x < 0) point.x = width;
+        if (point.x > width) point.x = 0;
+        if (point.y < 0) point.y = height;
+        if (point.y > height) point.y = 0;
+
+        ctx.beginPath();
+        ctx.arc(point.x, point.y, point.r, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(${point.cr},${point.cg},${point.cb},${point.op})`;
+        ctx.fill();
+      }
+
+      ctx.lineWidth = 0.4;
+      for (let i = 0; i < count; i += 1) {
+        for (let j = i + 1; j < count; j += 1) {
+          const dx = points[i].x - points[j].x;
+          const dy = points[i].y - points[j].y;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+          if (distance < 105) {
+            ctx.strokeStyle = `rgba(185,210,225,${(1 - distance / 105) * 0.16})`;
+            ctx.beginPath();
+            ctx.moveTo(points[i].x, points[i].y);
+            ctx.lineTo(points[j].x, points[j].y);
+            ctx.stroke();
+          }
+        }
+      }
+
+      canvasAnimationId = window.requestAnimationFrame(draw);
+    };
+
+    tickCursor();
+    draw();
+
+    return () => {
+      window.cancelAnimationFrame(cursorAnimationId);
+      window.cancelAnimationFrame(canvasAnimationId);
+      document.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('resize', onResize);
+    };
+  }, []);
+
   return (
-    <div className="min-h-screen bg-white text-gray-900 font-sans">
-      <Navbar />
-      <main>
-        <Hero />
-        <About />
-        <Industries />
-{/*         <Brands /> */}
-        <Capabilities />
-        <Contact />
-      </main>
-      <Footer />
-    </div>
+    <>
+      <div className="cursor" ref={cursorRef} />
+      <div className="cursor-ring" ref={cursorRingRef} />
+
+      <canvas id="c" ref={canvasRef} />
+
+      <div className="title-wrap">
+        <div className="title-glow" />
+        <div className="company-name">Arkridge Industries</div>
+        <div className="title-line" />
+        <div className="tagline">Engineering Solutions For TOMORROW</div>
+      </div>
+
+      <div className="contact">
+        <div className="contact-bar" />
+        <a className="contact-link" ref={contactRef}>
+          <span className="t1" />
+          <span className="t2" />
+          <span className="b1" />
+          <span className="b2" />
+          <span className="l1" />
+          <span className="l2" />
+          <span className="r1" />
+          <span className="r2" />
+          Contact Us
+        </a>
+      </div>
+
+      <div className="copyright">
+        <span className="copyright-text">© 2025 Arkridge Industries Private Limited</span>
+        <div className="copyright-dot" />
+        <span className="copyright-text">All Rights Reserved</span>
+      </div>
+    </>
   );
 }
 
-export default App
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,38 +1,313 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300&display=swap');
 
-@layer base {
-  html {
-    scroll-behavior: smooth;
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #2a3138;
+  font-family: 'Montserrat', sans-serif;
+  cursor: none;
+}
+
+canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  z-index: 0;
+}
+
+.cursor {
+  position: fixed;
+  width: 6px;
+  height: 6px;
+  background: #fff;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 999;
+  transform: translate(-50%, -50%);
+  opacity: 0.9;
+}
+
+.cursor-ring {
+  position: fixed;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 998;
+  transform: translate(-50%, -50%);
+}
+
+.title-wrap {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.title-glow {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 900px;
+  height: 220px;
+  background: radial-gradient(
+    ellipse at center,
+    rgba(255, 255, 255, 0.06) 0%,
+    rgba(255, 255, 255, 0.02) 40%,
+    transparent 70%
+  );
+  pointer-events: none;
+  filter: blur(12px);
+  animation: breathe 5s ease-in-out infinite;
+}
+
+@keyframes breathe {
+  0%,
+  100% {
+    opacity: 0.6;
+    transform: translate(-50%, -50%) scaleX(1);
   }
-  
-  body {
-    font-family: 'Inter', sans-serif;
+  50% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scaleX(1.07);
   }
 }
 
-@layer utilities {
-  .animate-fade-in {
-    animation: fadeIn 0.8s ease-out forwards;
+.company-name {
+  font-weight: 200;
+  font-size: clamp(24px, 3.65vw, 55px);
+  letter-spacing: 0.6em;
+  text-indent: 0.6em;
+  color: #ffffff;
+  text-transform: uppercase;
+  white-space: nowrap;
+  position: relative;
+  z-index: 2;
+  opacity: 0;
+  animation: fadein 2.2s ease forwards 0.5s;
+  text-shadow: -1px -1px 0px rgba(255, 255, 255, 0.55), 1px 1px 0px rgba(0, 0, 0, 0.75),
+    -2px -2px 1px rgba(255, 255, 255, 0.15), 2px 2px 2px rgba(0, 0, 0, 0.5), 0 0 40px rgba(255, 255, 255, 0.12),
+    0 0 90px rgba(255, 255, 255, 0.05);
+}
+
+.title-line {
+  height: 1px;
+  width: 0;
+  margin-top: 20px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.2) 10%,
+    rgba(255, 255, 255, 0.85) 50%,
+    rgba(255, 255, 255, 0.2) 90%,
+    transparent 100%
+  );
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.3), 0 0 20px rgba(255, 255, 255, 0.1);
+  position: relative;
+  z-index: 2;
+  animation: expand 2s cubic-bezier(0.77, 0, 0.18, 1) forwards 1.4s;
+}
+
+.tagline {
+  font-weight: 200;
+  font-size: clamp(9px, 1vw, 13px);
+  letter-spacing: 0.45em;
+  text-indent: 0.45em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.47);
+  margin-top: 16px;
+  position: relative;
+  z-index: 2;
+  opacity: 0;
+  animation: fadein 2s ease forwards 2.2s;
+}
+
+@keyframes fadein {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
   }
-  
-  .animate-fade-in-delayed {
-    animation: fadeIn 0.8s ease-out 0.3s forwards;
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
-  
-  .animate-fade-in-delayed-more {
-    animation: fadeIn 0.8s ease-out 0.6s forwards;
+}
+
+@keyframes expand {
+  from {
+    width: 0;
+    opacity: 0;
   }
-  
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-      transform: translateY(20px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
+  to {
+    width: clamp(240px, 36vw, 560px);
+    opacity: 1;
   }
+}
+
+.contact {
+  position: fixed;
+  bottom: 88px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  opacity: 0;
+  animation: fadein 1.6s ease forwards 2.6s;
+}
+
+.contact-bar {
+  width: 1px;
+  height: 30px;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.35), transparent);
+}
+
+.contact-link {
+  font-weight: 200;
+  font-size: 12px;
+  letter-spacing: 0.42em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+  text-decoration: none;
+  cursor: none;
+  padding: 10px 32px;
+  position: relative;
+  transition: color 0.35s;
+  padding-left: calc(32px + 0.42em);
+}
+
+.contact-link span {
+  position: absolute;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.contact-link .t1 {
+  top: 0;
+  left: 50%;
+  height: 1px;
+  width: 0;
+  transition: width 0.28s ease;
+}
+
+.contact-link .t2 {
+  top: 0;
+  right: 50%;
+  height: 1px;
+  width: 0;
+  transition: width 0.28s ease;
+}
+
+.contact-link .b1 {
+  bottom: 0;
+  left: 50%;
+  height: 1px;
+  width: 0;
+  transition: width 0.28s ease 0.05s;
+}
+
+.contact-link .b2 {
+  bottom: 0;
+  right: 50%;
+  height: 1px;
+  width: 0;
+  transition: width 0.28s ease 0.05s;
+}
+
+.contact-link .l1 {
+  left: 0;
+  top: 50%;
+  width: 1px;
+  height: 0;
+  transition: height 0.22s ease 0.12s;
+}
+
+.contact-link .l2 {
+  left: 0;
+  bottom: 50%;
+  width: 1px;
+  height: 0;
+  transition: height 0.22s ease 0.12s;
+}
+
+.contact-link .r1 {
+  right: 0;
+  top: 50%;
+  width: 1px;
+  height: 0;
+  transition: height 0.22s ease 0.12s;
+}
+
+.contact-link .r2 {
+  right: 0;
+  bottom: 50%;
+  width: 1px;
+  height: 0;
+  transition: height 0.22s ease 0.12s;
+}
+
+.contact-link:hover {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.contact-link:hover .t1,
+.contact-link:hover .t2,
+.contact-link:hover .b1,
+.contact-link:hover .b2 {
+  width: 50%;
+}
+
+.contact-link:hover .l1,
+.contact-link:hover .l2,
+.contact-link:hover .r1,
+.contact-link:hover .r2 {
+  height: 50%;
+}
+
+.copyright {
+  position: fixed;
+  bottom: 28px;
+  left: 48px;
+  z-index: 10;
+  opacity: 0;
+  animation: fadein 1.6s ease forwards 3s;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.copyright-text {
+  font-weight: 200;
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.3);
+  white-space: nowrap;
+}
+
+.copyright-dot {
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.15);
+  flex-shrink: 0;
 }


### PR DESCRIPTION
### Motivation
- Replace the existing multi-section React site with the provided Arkridge HTML/CSS/JS to deliver a single cinematic landing experience.
- Port the inline JavaScript behaviors (custom cursor, animated particle canvas, mailto composition) into React lifecycle hooks for maintainability.

### Description
- Replaced `src/App.tsx` to render the single-page layout and ported the original inline script to a `useEffect` hook that sets up refs, event listeners, RAF loops, canvas drawing, and cleanup.
- Added refs for the `canvas`, `cursor`, `cursorRing`, and `contact` elements and implemented particle generation, drawing, canvas resize handling, cursor tracking, and dynamic `mailto` link composition.
- Replaced `src/index.css` with the provided stylesheet including font import, full-screen background, custom cursor/ring styling, title glow and animations, contact border-draw hover effects, and footer styling.
- Removed the previous multi-section UI rendering and instead output the new layout elements (`canvas`, `.title-wrap`, `.contact`, copyright).

### Testing
- Ran `npm run build` which completed successfully (Vite produced the `dist` build).
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and performed visual verification; a screenshot was captured via Playwright for confirmation.
- No automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a96c04e7cc8321b6fe99f336c8db79)